### PR TITLE
Increase max ICE candidates to 128

### DIFF
--- a/config_site.h
+++ b/config_site.h
@@ -1,7 +1,7 @@
 #ifndef __PJ_CONFIG_SITE_H__
 #define __PJ_CONFIG_SITE_H__
 
-#define PJ_ICE_MAX_CAND 32
+#define PJ_ICE_MAX_CAND 128
 #define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * 2)
 
 #endif /* __PJ_CONFIG_SITE_H__ */

--- a/config_site.h
+++ b/config_site.h
@@ -1,7 +1,7 @@
 #ifndef __PJ_CONFIG_SITE_H__
 #define __PJ_CONFIG_SITE_H__
 
-#define PJ_ICE_MAX_CAND 128
-#define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * 2)
+#define PJ_ICE_MAX_CAND 32
+#define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * 16)
 
 #endif /* __PJ_CONFIG_SITE_H__ */


### PR DESCRIPTION
The following issue still happens while running chan_respoke on docker behind a NAT. Signaling seems good, but an error happens on asterisk as well as in the web browser. This was suggested by Matt Jordan as a possible fix.

asterisk:

``` plain
[Aug  5 14:26:12] WARNING[109]: res_rtp_asterisk.c:784 ast_rtp_ice_start: Failed to create ICE session check list: Too many objects of the specified type (PJ_ETOOMANY) (0x7f9fb004b4f8)
```

chrome 51.0.2704.103 (64-bit)

``` plain
...
[Respoke] PC handleAnswerSignal Object {signal: Object, name: "signal-answer", target: Object}
respoke.min.js:2 [Respoke] got answer Object {answer: "final", signalType: "answer", version: "1.0", sessionId: "5743E90E-3919-4156-B9AA-419BE8CE8B09", parsedSDP: Object…}
respoke.min.js:2 [Respoke] Call handleAnswerSignal Object {signal: Object, name: "signal-answer", target: Object}
respoke.min.js:2 [Respoke] Exception calling setRemoteDescription on answer I received. DOMException: Failed to set remote answer sdp: Called in wrong state: STATE_INPROGRESS(anonymous function) @ respoke.min.js:2errorHandler @ respoke.min.js:41
respoke.min.js:2 [Respoke] fired respoke.Call#error 0 listeners called with params Object {message: "Exception calling setRemoteDescription on answer I received.", name: "error", target: Object}
respoke.min.js:2 [Respoke] set remote desc of answer failed Object {sdp: "v=0
↵o=- 431878786 2 IN IP4 0.0.0.0
↵s=Asterisk
↵t…4994 typ relay raddr 50.173.112.172 rport 57829
↵", type: "answer"} DOMException: Failed to set remote answer sdp: Called in wrong state: STATE_INPROGRESS(anonymous function) @ respoke.min.js:2errorHandler @ respoke.min.js:41
respoke.min.js:2 [Respoke] sending hangup
...
```
